### PR TITLE
[TASK] Add dependencies of other extensions in code format

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
 			},
 			{
 				"command": "sfmc-devtools-vscext.devtoolsCMCopyToBU",
-				"title": "mcdev: Copy to Business Unit"
+				"title": "mcdev: Copy to Business Unit..."
 			}
 		],
 		"menus": {
@@ -91,6 +91,15 @@
 					"group": "devtools"
 				}
 			]
+		},
+		"configuration":{
+			"title": "sfmc-devtools-vscode",
+			"properties": {
+				"sfmc-devtools-vscode.recommendedExtensions": {
+					"type": "boolean",
+					"default": true
+				}
+			}
 		}
 	},
 	"scripts": {

--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
 		"configuration":{
 			"title": "sfmc-devtools-vscode",
 			"properties": {
-				"sfmc-devtools-vscode.recommendedExtensions": {
+				"sfmc-devtools-vscode.recommendExtensions": {
 					"type": "boolean",
 					"default": true
 				}

--- a/src/config/main.config.ts
+++ b/src/config/main.config.ts
@@ -3,6 +3,7 @@ export const mainConfig: {
     requiredFiles: string[],
     fileExtensions: string[],
     allPlaceholder: string,
+    extensionsDependencies: string[],
     messages: {
         selectedCredentialsBU: string,
         selectCredential: string, 
@@ -21,6 +22,7 @@ export const mainConfig: {
     requiredFiles: [".mcdevrc.json", ".mcdev-auth.json"],
     fileExtensions: ["meta.json", "meta.sql", "meta.html", "meta.ssjs", "doc.md"],
     allPlaceholder: "*All*",
+    extensionsDependencies: ["IBM.output-colorizer"],
     messages: {
         selectedCredentialsBU: "Select a Credential/BU before running the command",
         selectCredential: "Select one of the credentials below...",

--- a/src/devtools/main.ts
+++ b/src/devtools/main.ts
@@ -9,6 +9,7 @@ import { editorInput } from "../editor/input";
 import { editorContext } from "../editor/context";
 import { editorWorkspace } from "../editor/workspace";
 import { editorOutput, log } from "../editor/output";
+import { editorDependencies } from "../editor/dependencies";
 import { InstallDevToolsResponseOptions } from "../config/installer.config";
 import { lib } from "../shared/utils/lib";
 import { file } from "../shared/utils/file";
@@ -19,8 +20,11 @@ async function initDevToolsExtension(): Promise<void>{
     try{
         log("info", "Running SFMC DevTools extension...");
 
+        editorDependencies.activateExtensionDependencies(mainConfig.extensionsDependencies);
+
         // activate the status bar
         devtoolsContainers.activateStatusBar();
+
         // activate the context menus options
         devtoolsContainers.activateContextMenuCommands();
 

--- a/src/editor/commands.ts
+++ b/src/editor/commands.ts
@@ -16,7 +16,7 @@ function executeCommand(command: string | string[], args: (string | boolean | st
     [command]
         .flat()
         .forEach(
-            (command: string) => commands.executeCommand(command, ...args)
+            async (command: string) => await commands.executeCommand(command, ...args)
         );
 }
 

--- a/src/editor/dependencies.ts
+++ b/src/editor/dependencies.ts
@@ -20,7 +20,7 @@ async function activateExtensionDependencies(dependencies: string | string[]){
     if(missingExtDependencies.length){
 
         const suggestRecommendedExtensions: string | boolean = 
-            editorWorkspace.handleWorkspaceConfiguration("recommendedExtensions", true).get();
+            editorWorkspace.handleWorkspaceConfiguration("recommendExtensions", true).get();
 
         if(suggestRecommendedExtensions){
             const message: string = "There are some recommended extensions that can enhance your usage of SFMC DevTools. Would you like to install them?";
@@ -35,7 +35,7 @@ async function activateExtensionDependencies(dependencies: string | string[]){
                         );
                     });
                 }else if(selectedOption === RecommendedExtensionsInputOptions.DONT_ASK_AGAIN){
-                    editorWorkspace.handleWorkspaceConfiguration("recommendedExtensions", false).set();
+                    editorWorkspace.handleWorkspaceConfiguration("recommendExtensions", false).set();
                 }
             }
         }

--- a/src/editor/dependencies.ts
+++ b/src/editor/dependencies.ts
@@ -1,0 +1,49 @@
+/* eslint-disable @typescript-eslint/naming-convention */
+import { extensions } from "vscode";
+import { editorWorkspace } from "./workspace";
+import { editorInput } from "./input";
+import { editorCommands } from "./commands";
+
+enum RecommendedExtensionsInputOptions {
+    INSTALL = "Install",
+    NOT_NOW = "Not Now",
+    DONT_ASK_AGAIN = "Do not show again"
+};
+
+async function activateExtensionDependencies(dependencies: string | string[]){
+    
+    const missingExtDependencies: string[] = 
+        [dependencies]
+            .flat()
+            .filter((dependencyName: string) => !extensions.getExtension(dependencyName));
+
+    if(missingExtDependencies.length){
+
+        const suggestRecommendedExtensions: string | boolean = 
+            editorWorkspace.handleWorkspaceConfiguration("recommendedExtensions", true).get();
+
+        if(suggestRecommendedExtensions){
+            const message: string = "There are some recommended extensions that can enhance your usage of SFMC DevTools. Would you like to install them?";
+            const options: string[] = Object.values(RecommendedExtensionsInputOptions);
+            const selectedOption: string | undefined = await editorInput.handleShowOptionsMessage(message, options);
+            if(selectedOption){
+                if(selectedOption === RecommendedExtensionsInputOptions.INSTALL){
+                    missingExtDependencies.forEach((extDependency: string) => {
+                        editorCommands.executeCommand(
+                            ["extension.open", "workbench.extensions.installExtension"], 
+                            [extDependency]
+                        );
+                    });
+                }else if(selectedOption === RecommendedExtensionsInputOptions.DONT_ASK_AGAIN){
+                    editorWorkspace.handleWorkspaceConfiguration("recommendedExtensions", false).set();
+                }
+            }
+        }
+    }
+}
+
+const editorDependencies = {
+    activateExtensionDependencies
+};
+
+export { editorDependencies };

--- a/src/editor/workspace.ts
+++ b/src/editor/workspace.ts
@@ -1,4 +1,4 @@
-import { workspace, Uri, TextDocument, WorkspaceFolder, FileType, FileStat } from "vscode";
+import { workspace, Uri, TextDocument, WorkspaceFolder, FileType, FileStat, WorkspaceConfiguration, ConfigurationTarget } from "vscode";
 import { editorCommands } from "./commands";
 
 function getWorkspaceURI(): Uri {
@@ -53,12 +53,24 @@ async function isFile(file: string | Uri){
     return fileType.toLowerCase() === "file";
 }
 
+function handleWorkspaceConfiguration(key: string, value: string | boolean){
+    const workspaceConfiguration: WorkspaceConfiguration = workspace.getConfiguration("sfmc-devtools-vscode");
+    if(workspaceConfiguration){
+        return {
+            get: () => workspaceConfiguration.get(key, value),
+            set: () => workspaceConfiguration.update(key, value, ConfigurationTarget.Workspace)
+        };
+    }
+    throw new Error("Failed to handle Workspace Configuration.");
+}
+
 export const editorWorkspace = {
     isFileInFolder,
     readFile,
     reloadWorkspace,
     getWorkspaceURIPath,
     getWorkspaceSubFolders,
+    handleWorkspaceConfiguration,
     getFilesURIPath,
     isFile
 };


### PR DESCRIPTION
# PR details

## What changes did you make? (Give an overview)

- Updated workspace to include vscode getConfiguration method
- Add a dependencies class to handle the input from the user regarding the decision to install or not the recommend extensions. If the user selects "Do not ask again" a variable sfmc-devtools-vscode.recommendExtensions will be set to False in order to avoid asking again. This variable will be set by Workspace, not on the Global level.
- Update package.json to include ... in mcdev: Copy to Business Unit and configuration of Workspace variable  

- closes #100 
