### PR TITLE
updated logs to have clickable file paths

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,6 +74,10 @@
 				{
 					"command": "sfmc-devtools-vscext.devtoolsCMDeploy",
 					"when": "false"
+				},
+				{
+					"command": "sfmc-devtools-vscext.devtoolsCMCopyToBU",
+					"when": "false"
 				}
 			],
 			"editor/title/context": [

--- a/src/devtools/main.ts
+++ b/src/devtools/main.ts
@@ -580,9 +580,6 @@ async function handleCopyToBuCMCommand(selectedPaths: string[]){
             COPY_AND_DEPLOY = `$(${StatusBarIcon.deploy})  Copy & Deploy`
         }
 
-        const getFileInstancePath: (fileInstancePath: string) => string | undefined = 
-            (fileInstancePath: string) => fileInstancePath.split(/\/retrieve\/|\/deploy\//)[1];
-
         const actionOptionList: InputOptionsSettings[] = 
             Object.values(CopyToBUInputOptions).map((action: string) => ({ id: action, label: action, detail: "" }));
 
@@ -626,7 +623,7 @@ async function handleCopyToBuCMCommand(selectedPaths: string[]){
 
                         const filePathsConfigured: FileCopyConfig[] = 
                             selectedPaths.map((path: string) => {
-                                const fileInstancePath: string | undefined = getFileInstancePath(path);
+                                const [ _, fileInstancePath ]: string[] = path.split(/\/retrieve\/|\/deploy\//);
 
                                 if(fileInstancePath){
                                     const [ _, businessUnit ]: string[] = fileInstancePath.split("/");
@@ -679,13 +676,13 @@ async function handleCopyToBuCMCommand(selectedPaths: string[]){
                         if(selectedAction.label === CopyToBUInputOptions.COPY_AND_DEPLOY){
                             handleDevToolsCMCommand("deploy", targetFilePaths);
                         }
+
                         log("info", 
-                            `Copying to the deploy folder${selectedAction.label === CopyToBUInputOptions.COPY_AND_DEPLOY ? " and Deploying " : " "}the following selected files:\n` +
-                            `${
-                                targetFilePaths.map((targetFilePath: string) => getFileInstancePath(targetFilePath))
-                                .filter((filePath: string | undefined) => filePath !== undefined)
-                                .join("\n")
-                        }`);
+                            `Copying to the deploy folder`+
+                            `${selectedAction.label === CopyToBUInputOptions.COPY_AND_DEPLOY ? " and Deploying " : " "}`+
+                            `the following selected files:\n` +
+                            editorWorkspace.getFileSystemPaths(targetFilePaths).join("\n")
+                        );
                     }
                 }
             }else{

--- a/src/editor/workspace.ts
+++ b/src/editor/workspace.ts
@@ -64,6 +64,12 @@ function handleWorkspaceConfiguration(key: string, value: string | boolean){
     throw new Error("Failed to handle Workspace Configuration.");
 }
 
+function getFileSystemPaths(paths: string | string[]){
+    return [paths]
+        .flat()
+        .map((path: string) => Uri.file(path).fsPath);
+}
+
 export const editorWorkspace = {
     isFileInFolder,
     readFile,
@@ -72,5 +78,6 @@ export const editorWorkspace = {
     getWorkspaceSubFolders,
     handleWorkspaceConfiguration,
     getFilesURIPath,
-    isFile
+    isFile,
+    getFileSystemPaths
 };


### PR DESCRIPTION
# PR details

## What changes did you make? (Give an overview)

- Absolute file paths are now displayed in the Output channel SFMC DevTools  for copied files.
- closes #119 
