### PR TITLE
Bug/120 copy to bu should not copy markdownmd files

### DIFF
--- a/src/config/main.config.ts
+++ b/src/config/main.config.ts
@@ -2,6 +2,7 @@ export const mainConfig: {
     credentialsFilename: string,
     requiredFiles: string[],
     fileExtensions: string[],
+    noCopyFileExtensions: string[],
     allPlaceholder: string,
     extensionsDependencies: string[],
     messages: {
@@ -21,6 +22,7 @@ export const mainConfig: {
     credentialsFilename: ".mcdevrc.json",
     requiredFiles: [".mcdevrc.json", ".mcdev-auth.json"],
     fileExtensions: ["meta.json", "meta.sql", "meta.html", "meta.ssjs", "doc.md"],
+    noCopyFileExtensions: ["doc.md"],
     allPlaceholder: "*All*",
     extensionsDependencies: ["IBM.output-colorizer"],
     messages: {

--- a/src/devtools/main.ts
+++ b/src/devtools/main.ts
@@ -643,9 +643,9 @@ async function handleCopyToBuCMCommand(selectedPaths: string[]){
                                                 paths = [
                                                     ...paths, 
                                                     ...file.fileExists(
-                                                        mainConfig.fileExtensions.map((fileExtension: string) => 
-                                                            path.replace(currentFileExt, fileExtension)
-                                                        )
+                                                        mainConfig.fileExtensions
+                                                            .filter((fileExtension: string) => !mainConfig.noCopyFileExtensions.includes(fileExtension))
+                                                            .map((fileExtension: string) => path.replace(currentFileExt, fileExtension))
                                                     )
                                                 ];
                                             }


### PR DESCRIPTION
# PR details

## What changes did you make? (Give an overview)

- Markdown files .md are not included in the deploy folder when the user selects Copy or Copy & Deploy.
- closes #120 
