### PR TITLE
Bug/118 supported actions explaintypes json not considered

### DIFF
--- a/src/config/main.config.ts
+++ b/src/config/main.config.ts
@@ -17,6 +17,7 @@ export const mainConfig: {
         runningCommand: string,
         successRunningCommand: string,
         failureRunningCommand: string,
+        unsupportedMetadataType: string
     }
 } = {
     credentialsFilename: ".mcdevrc.json",
@@ -36,6 +37,7 @@ export const mainConfig: {
         copyToBUInput: "Select one of the actions below...",
         runningCommand: "Running DevTools Command...",
         successRunningCommand: "DevTools Command has run successfully.",
-        failureRunningCommand: "Oh no. Something went wrong while running DevTools Command. Please check the error by clicking on the mcdev button in the status bar."
+        failureRunningCommand: "Oh no. Something went wrong while running DevTools Command. Please check the error by clicking on the mcdev button in the status bar.",
+        unsupportedMetadataType: "SFMC DevTools currently does not support one or more of the selected metadata types. Find out which ones are impacted by clicking on the mcdev button in the status bar."
     }
 };

--- a/src/config/main.config.ts
+++ b/src/config/main.config.ts
@@ -37,7 +37,7 @@ export const mainConfig: {
         copyToBUInput: "Select one of the actions below...",
         runningCommand: "Running DevTools Command...",
         successRunningCommand: "DevTools Command has run successfully.",
-        failureRunningCommand: "Oh no. Something went wrong while running DevTools Command. Please check the error by clicking on the mcdev button in the status bar.",
-        unsupportedMetadataType: "SFMC DevTools currently does not support one or more of the selected metadata types. Find out which ones are impacted by clicking on the mcdev button in the status bar."
+        failureRunningCommand: "Oh no. Something went wrong while running DevTools Command.",
+        unsupportedMetadataType: "SFMC DevTools currently does not support one or more of the selected metadata types."
     }
 };

--- a/src/devtools/commands/DevToolsAdminCommands.ts
+++ b/src/devtools/commands/DevToolsAdminCommands.ts
@@ -40,7 +40,9 @@ class DevToolsAdminCommands extends DevToolsCommands {
         }
     }
 
+    getMetadataTypes(): SupportedMetadataTypes[] | void {}
     setMetadataTypes(_: SupportedMetadataTypes[]): void {}
+    isSupportedMetadataType(_action: string, _metadataType: string): boolean | void {}
 
     async init(
         config: DevToolsCommandSetting,

--- a/src/devtools/commands/DevToolsCommands.ts
+++ b/src/devtools/commands/DevToolsCommands.ts
@@ -16,6 +16,8 @@ abstract class DevToolsCommands {
 
     abstract run(commandRunner: DevToolsCommandRunner): void;
     abstract setMetadataTypes(mdTypes: SupportedMetadataTypes[]): void;
+    abstract getMetadataTypes(): SupportedMetadataTypes[] | void;
+    abstract isSupportedMetadataType(action: string, metadataType: string): boolean | void;
 
     executeCommand(command: string, path: string, showOnTerminal: boolean): Promise<string | number>{
         log("info", `Running DevTools Command: ${command}`);
@@ -238,6 +240,17 @@ abstract class DevToolsCommands {
             return commandsConfig[id as keyof typeof commandsConfig].requireCredentials;
         }
         log("error", `[DevToolsCommands_runCommand] Error: Failed to retrieve ${id} from commands configuration.`);
+        return false;
+    }
+
+    static isSupportedMetadataType(action: string, metadataType: string){
+        if("standard" in this.commandMap){
+            const devToolsCommand: DevToolsCommands = this.commandMap["standard"];
+            return devToolsCommand.isSupportedMetadataType(action, metadataType);
+        }
+        log("error", 
+            `[DevToolsCommands_isSupportedMetadataType] Error: Failed to retrieve DevTools Standard Commands from commands configuration.`
+        );
         return false;
     }
 }

--- a/src/devtools/containers.ts
+++ b/src/devtools/containers.ts
@@ -11,7 +11,8 @@ enum StatusBarIcon {
     retrieve = "cloud-download",
     deploy = "cloud-upload",
     error = "warning",
-    copy_to_folder = "file-symlink-directory" 
+    copy_to_folder = "file-symlink-directory",
+    info = "extensions-info-message"
 }
 
 // Contains all the status bars that are displayed in the extension

--- a/src/devtools/main.ts
+++ b/src/devtools/main.ts
@@ -386,12 +386,12 @@ function logUnsupportedMtdtTypeNotification(action: string, unsupportedMtdtTypes
     .flat()
     .forEach((metadataType: string) => {
         log(
-            "info", 
-            `SFMC DevTools currently does not support ${action} for the metadata type: '${metadataType}'`
+            "error", 
+            `Error: SFMC DevTools currently does not support ${action} for the metadata type: '${metadataType}'`
         );
     });
-    devtoolsContainers.modifyStatusBar("mcdev", "info");
-    editorInput.handleShowNotificationMessage("info", mainConfig.messages.unsupportedMetadataType, []);
+    devtoolsContainers.modifyStatusBar("mcdev", "error");
+    editorInput.handleShowNotificationMessage("error", mainConfig.messages.unsupportedMetadataType, []);
 };
 
 async function handleDevToolsCMCommand(action: string, selectedPaths: string[]): Promise<void>{

--- a/src/devtools/main.ts
+++ b/src/devtools/main.ts
@@ -629,9 +629,6 @@ async function handleCopyToBuCMCommand(selectedPaths: string[]){
 
         }, { supportedMetadataTypes: [], unSupportedMetadataTypes: [] });
 
-        console.log('deployableMetadata = ', supportedMetadataTypes);
-        console.log('nonDeployableMetadata = ', unSupportedMetadataTypes);
-
         if(unSupportedMetadataTypes.length){
             
             const uniqueMetadataTypes: string[] = 

--- a/src/editor/input.ts
+++ b/src/editor/input.ts
@@ -34,19 +34,19 @@ async function handleInProgressMessage(local: string, callbackFn: (progress: Pro
     );
 }
 
-function handleShowNotificationMessage(level: keyof typeof NotificationMessage, message: string){
+function handleShowNotificationMessage(level: keyof typeof NotificationMessage, message: string, actions: string[]){
     switch(level){
         case "info":
-            window.showInformationMessage(message);
+            window.showInformationMessage(message, ...actions);
             break;
         case "warning":
-            window.showWarningMessage(message);
+            window.showWarningMessage(message, ...actions);
             break;
         case "error":
-            window.showErrorMessage(message);
+            window.showErrorMessage(message, ...actions);
             break;
         default:
-            window.showInformationMessage(message);
+            window.showInformationMessage(message, ...actions);
     }
 }
 

--- a/src/editor/input.ts
+++ b/src/editor/input.ts
@@ -37,16 +37,16 @@ async function handleInProgressMessage(local: string, callbackFn: (progress: Pro
 function handleShowNotificationMessage(level: keyof typeof NotificationMessage, message: string, actions: string[]){
     switch(level){
         case "info":
-            window.showInformationMessage(message, ...actions);
+            window.showInformationMessage(message, ...actions, "Close");
             break;
         case "warning":
-            window.showWarningMessage(message, ...actions);
+            window.showWarningMessage(message, ...actions, "Close");
             break;
         case "error":
-            window.showErrorMessage(message, ...actions);
+            window.showErrorMessage(message, ...actions, "Close");
             break;
         default:
-            window.showInformationMessage(message, ...actions);
+            window.showInformationMessage(message, ...actions, "Close");
     }
 }
 

--- a/src/shared/interfaces/devToolsPathComponents.ts
+++ b/src/shared/interfaces/devToolsPathComponents.ts
@@ -1,0 +1,8 @@
+interface DevToolsPathComponents {
+    credentialName: string,
+    businessUnit: string,
+    metadataType: string,
+    keys: string[]
+}
+
+export default DevToolsPathComponents;


### PR DESCRIPTION
# PR details

## What changes did you make? (Give an overview)

- All the menu action (Copy, Deploy and Retrieve) now check if if they are supported in SFMC DevTools according to the following retrieved from the explainTypes command:
     - retrieve -> retrieve
     - deploy -> create || update
     - copy -> create || update
     - copy & deploy --> create || update 

- Notification Message is displayed when one or more metadata types is not supported
![image](https://github.com/Accenture/sfmc-devtools-vscode/assets/66126240/2ddab24a-04fe-4d70-810b-26a4f81c62e6)

- closes #118 
