### PR TITLE
bug/159 deploy option does not show up on folders in assetmessages folder

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,12 @@
                "group": "devtools"
             },
             {
-               "when": "resourcePath =~ /deploy/ || (resourcePath =~ /retrieve/ && (resourceExtname == '.json' || resourceExtname == '.html' || resourceExtname == '.sql' || resourceExtname == '.ssjs' || resourceLangId == 'markdown' || resourceLangId == 'AMPscript'))",
+               "when": "resourcePath =~ /deploy/",
+               "command": "sfmc-devtools-vscext.devtoolsCMDeploy",
+               "group": "devtools"
+            },
+            {
+               "when": "resourcePath =~ /retrieve/ && (resourceExtname == '.json' || resourceExtname == '.html' || resourceExtname == '.sql' || resourceExtname == '.ssjs' || resourceLangId == 'markdown' || resourceLangId == 'AMPscript' || resourceDirname =~ /asset\\\\[a-zA-Z]*/)",
                "command": "sfmc-devtools-vscext.devtoolsCMDeploy",
                "group": "devtools"
             },
@@ -97,7 +102,12 @@
                "group": "devtools"
             },
             {
-               "when": "resourcePath =~ /deploy/ || (resourcePath =~ /retrieve/ && (resourceExtname == '.json' || resourceExtname == '.html' || resourceExtname == '.sql' || resourceExtname == '.ssjs' || resourceLangId == 'markdown' || resourceLangId == 'AMPscript'))",
+               "when": "resourcePath =~ /deploy/",
+               "command": "sfmc-devtools-vscext.devtoolsCMDeploy",
+               "group": "devtools"
+            },
+            {
+               "when": "resourcePath =~ /retrieve/ && (resourceExtname == '.json' || resourceExtname == '.html' || resourceExtname == '.sql' || resourceExtname == '.ssjs' || resourceLangId == 'markdown' || resourceLangId == 'AMPscript')",
                "command": "sfmc-devtools-vscext.devtoolsCMDeploy",
                "group": "devtools"
             },


### PR DESCRIPTION
# PR details

## What changes did you make? (Give an overview)

Updated package.json to consider when deploying assets from the retrieve folder to consider all the folder that are inside the specific asset folders (message, block, other, ...)

closes #159 
