### PR TITLE
163 feature offer active file ctrl+shift p commands

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -12,7 +12,7 @@
         "@typescript-eslint/naming-convention": "off",
         "@typescript-eslint/semi": "warn",
         "@typescript-eslint/camelcase": "off",
-        "curly": "off",
+        "curly": "warn",
         "eqeqeq": "warn",
         "no-throw-literal": "warn",
         "semi": "off"

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -12,7 +12,7 @@
         "@typescript-eslint/naming-convention": "off",
         "@typescript-eslint/semi": "warn",
         "@typescript-eslint/camelcase": "off",
-        "curly": "warn",
+        "curly": "off",
         "eqeqeq": "warn",
         "no-throw-literal": "warn",
         "semi": "off"

--- a/package.json
+++ b/package.json
@@ -79,15 +79,15 @@
          "commandPalette": [
             {
                "command": "sfmc-devtools-vscext.devtoolsCMRetrieve",
-               "when": "false"
+               "when": "sfmc-devtools-vscode.isDevToolsProject"
             },
             {
                "command": "sfmc-devtools-vscext.devtoolsCMDeploy",
-               "when": "false"
+               "when": "sfmc-devtools-vscode.isDevToolsProject"
             },
             {
                "command": "sfmc-devtools-vscext.devtoolsCMCopyToBU",
-               "when": "false"
+               "when": "sfmc-devtools-vscode.isDevToolsProject"
             }
          ],
          "editor/title/context": [

--- a/package.json
+++ b/package.json
@@ -59,6 +59,20 @@
          }
       ],
       "menus": {
+         "commandPalette": [
+            {
+               "command": "sfmc-devtools-vscext.devtoolsCMRetrieve",
+               "when": "sfmc-devtools-vscode.isDevToolsProject && editorIsOpen && resourcePath =~ /retrieve/"
+            },
+            {
+               "command": "sfmc-devtools-vscext.devtoolsCMDeploy",
+               "when": "sfmc-devtools-vscode.isDevToolsProject && editorIsOpen && (resourcePath =~ /deploy/ || (resourcePath =~ /retrieve/ && (resourceExtname == '.json' || resourceExtname == '.html' || resourceExtname == '.sql' || resourceExtname == '.ssjs' || resourceLangId == 'markdown' || resourceLangId == 'AMPscript' || resourceLangId == 'ampscript')))"
+            },
+            {
+               "command": "sfmc-devtools-vscext.devtoolsCMCopyToBU",
+               "when": "sfmc-devtools-vscode.isDevToolsProject && editorIsOpen && resourcePath =~ /retrieve/"
+            }
+         ],
          "explorer/context": [
             {
                "when": "sfmc-devtools-vscode.isDevToolsProject && resourcePath =~ /retrieve/",
@@ -74,20 +88,6 @@
                "when": "sfmc-devtools-vscode.isDevToolsProject && resourcePath =~ /retrieve/ && resourceFilename != 'retrieve' && resourceFilename != 'deploy'",
                "command": "sfmc-devtools-vscext.devtoolsCMCopyToBU",
                "group": "devtools"
-            }
-         ],
-         "commandPalette": [
-            {
-               "command": "sfmc-devtools-vscext.devtoolsCMRetrieve",
-               "when": "sfmc-devtools-vscode.isDevToolsProject && editorIsOpen && resourcePath =~ /retrieve/"
-            },
-            {
-               "command": "sfmc-devtools-vscext.devtoolsCMDeploy",
-               "when": "sfmc-devtools-vscode.isDevToolsProject && editorIsOpen && (resourcePath =~ /deploy/ || (resourcePath =~ /retrieve/ && (resourceExtname == '.json' || resourceExtname == '.html' || resourceExtname == '.sql' || resourceExtname == '.ssjs' || resourceLangId == 'markdown' || resourceLangId == 'AMPscript' || resourceLangId == 'ampscript')))"
-            },
-            {
-               "command": "sfmc-devtools-vscext.devtoolsCMCopyToBU",
-               "when": "sfmc-devtools-vscode.isDevToolsProject && editorIsOpen && resourcePath =~ /retrieve/"
             }
          ],
          "editor/title/context": [

--- a/package.json
+++ b/package.json
@@ -79,15 +79,15 @@
          "commandPalette": [
             {
                "command": "sfmc-devtools-vscext.devtoolsCMRetrieve",
-               "when": "sfmc-devtools-vscode.isDevToolsProject"
+               "when": "sfmc-devtools-vscode.isDevToolsProject && editorIsOpen && resourcePath =~ /retrieve/"
             },
             {
                "command": "sfmc-devtools-vscext.devtoolsCMDeploy",
-               "when": "sfmc-devtools-vscode.isDevToolsProject"
+               "when": "sfmc-devtools-vscode.isDevToolsProject && editorIsOpen && (resourcePath =~ /deploy/ || (resourcePath =~ /retrieve/ && (resourceExtname == '.json' || resourceExtname == '.html' || resourceExtname == '.sql' || resourceExtname == '.ssjs' || resourceLangId == 'markdown' || resourceLangId == 'AMPscript' || resourceLangId == 'ampscript')))"
             },
             {
                "command": "sfmc-devtools-vscext.devtoolsCMCopyToBU",
-               "when": "sfmc-devtools-vscode.isDevToolsProject"
+               "when": "sfmc-devtools-vscode.isDevToolsProject && editorIsOpen && resourcePath =~ /retrieve/"
             }
          ],
          "editor/title/context": [

--- a/package.json
+++ b/package.json
@@ -123,20 +123,6 @@
                "command": "sfmc-devtools-vscext.devtoolsCMCopyToBU",
                "group": "devtools"
             }
-         ],
-         "commandPalette": [
-            {
-               "command": "sfmc-devtools-vscext.devtoolsCMRetrieve",
-               "when": "false"
-            },
-            {
-               "command": "sfmc-devtools-vscext.devtoolsCMDeploy",
-               "when": "false"
-            },
-            {
-               "command": "sfmc-devtools-vscext.devtoolsCMCopyToBU",
-               "when": "false"
-            }
          ]
       },
       "configuration": {

--- a/src/devtools/containers.ts
+++ b/src/devtools/containers.ts
@@ -177,12 +177,13 @@ function activateContextMenuCommands() {
 			callbackAction: (file: Uri, multipleFiles: Uri[]) => {
 				let filesURI: Uri[] = [];
 
+				// Gets the file uri that is currently open in the editor
+				const fileURI: Uri | undefined = editorContainers.getActiveTabFileURI();
+
 				// If file is undefined it could be that the command is being called from the commands palette
 				// else it should be the menu command
-				if (!file) {
-					// Gets the file uri that is currently open in the editor
-					const fileURI: Uri | undefined = editorContainers.getActiveTabFileURI();
-					if (fileURI) filesURI.push(fileURI);
+				if (!file && fileURI) {
+					filesURI.push(fileURI);
 				} else {
 					filesURI = !Array.isArray(multipleFiles) ? [file] : multipleFiles;
 				}
@@ -194,7 +195,6 @@ function activateContextMenuCommands() {
 					// Executes the command
 					return devtoolsMain.handleContextMenuActions(key, filesPath);
 				}
-				log("warning", "Warn: No file was selected or is currently open in the editor.");
 			}
 		})
 	);

--- a/src/devtools/containers.ts
+++ b/src/devtools/containers.ts
@@ -175,21 +175,21 @@ function activateContextMenuCommands() {
 		editorCommands.registerCommand({
 			command,
 			callbackAction: (file: Uri, multipleFiles: Uri[]) => {
-				let filesUri = [];
+				let filesURI: Uri[] = [];
 
 				// If file is undefined it could be that the command is being called from the commands palette
 				// else it should be the menu command
 				if (!file) {
 					// Gets the file uri that is currently open in the editor
 					const fileURI: Uri | undefined = editorContainers.getActiveTabFileURI();
-					filesUri = fileURI ? [fileURI] : [];
+					if (fileURI) filesURI.push(fileURI);
 				} else {
-					filesUri = !Array.isArray(multipleFiles) ? [file] : multipleFiles;
+					filesURI = !Array.isArray(multipleFiles) ? [file] : multipleFiles;
 				}
 
-				if (filesUri.length) {
+				if (filesURI.length) {
 					// Gets the file path from the URI
-					const filesPath: string[] = editorWorkspace.getFilesURIPath(filesUri);
+					const filesPath: string[] = editorWorkspace.getFilesURIPath(filesURI);
 					const [__, key]: string[] = command.split(".devtools");
 					// Executes the command
 					return devtoolsMain.handleContextMenuActions(key, filesPath);

--- a/src/devtools/containers.ts
+++ b/src/devtools/containers.ts
@@ -175,17 +175,26 @@ function activateContextMenuCommands() {
 		editorCommands.registerCommand({
 			command,
 			callbackAction: (file: Uri, multipleFiles: Uri[]) => {
-				const files: Uri[] = !Array.isArray(multipleFiles) ? [file] : multipleFiles;
-				if (files.length) {
-					const filesPath: string[] = editorWorkspace.getFilesURIPath(files);
-					const [__, key]: string[] = command.split(".devtools");
-					return devtoolsMain.handleContextMenuActions(key, filesPath);
+				let filesUri = [];
+
+				// If file is undefined it could be that the command is being called from the commands palette
+				// else it should be the menu command
+				if (!file) {
+					// Gets the file uri that is currently open in the editor
+					const fileURI: Uri | undefined = editorContainers.getActiveTabFileURI();
+					filesUri = fileURI ? [fileURI] : [];
 				} else {
-					log(
-						"error",
-						"[container_activateContextMenuCommands] Error: Context Menu Callback didn't return any selected files."
-					);
+					filesUri = !Array.isArray(multipleFiles) ? [file] : multipleFiles;
 				}
+
+				if (filesUri.length) {
+					// Gets the file path from the URI
+					const filesPath: string[] = editorWorkspace.getFilesURIPath(filesUri);
+					const [__, key]: string[] = command.split(".devtools");
+					// Executes the command
+					return devtoolsMain.handleContextMenuActions(key, filesPath);
+				}
+				log("warning", "Warn: No file was selected or is currently open in the editor.");
 			}
 		})
 	);

--- a/src/devtools/main.ts
+++ b/src/devtools/main.ts
@@ -119,7 +119,6 @@ function handleStatusBarActions(action: string): void {
 
 function handleContextMenuActions(action: string, selectedFiles: string[]): void {
 	devtoolsContainers.modifyStatusBar("mcdev", "success");
-
 	log("debug", "Setting Context Menu Actions...");
 	log("debug", `Action: ${action} Number of Selected Files: ${selectedFiles.length}`);
 	switch (action.toLowerCase()) {

--- a/src/editor/containers.ts
+++ b/src/editor/containers.ts
@@ -1,4 +1,4 @@
-import { window, StatusBarItem, StatusBarAlignment, ThemeColor } from "vscode";
+import { window, StatusBarItem, StatusBarAlignment, ThemeColor, Uri, Tab, TabInputText } from "vscode";
 
 function createStatusBarItem(command: string, title: string, name: string): StatusBarItem {
 	let statusBar: StatusBarItem = window.createStatusBarItem(StatusBarAlignment.Right, 110);
@@ -17,9 +17,19 @@ function getBackgroundColor(status: string) {
 	return new ThemeColor(`statusBarItem.${status}Background`);
 }
 
+function getActiveTabFileURI(): Uri | undefined {
+	const activeTab: Tab | undefined = window.tabGroups.activeTabGroup.activeTab;
+	if (activeTab && activeTab.input) {
+		const activeTabInput: TabInputText = activeTab.input as TabInputText;
+		return activeTabInput.uri;
+	}
+	return;
+}
+
 const editorContainers = {
 	createStatusBarItem,
 	displayStatusBarItem,
+	getActiveTabFileURI,
 	getBackgroundColor
 };
 

--- a/src/editor/output.ts
+++ b/src/editor/output.ts
@@ -39,7 +39,11 @@ function log(level: keyof typeof LogLevel, output: string | number | object, log
 		outputChannel.hide();
 	}
 
-	if (LogLevel[level] === LogLevel.info || LogLevel[level] === LogLevel.error) {
+	if (
+		LogLevel[level] === LogLevel.info ||
+		LogLevel[level] === LogLevel.error ||
+		LogLevel[level] === LogLevel.warning
+	) {
 		outputChannel.appendLine(`${outputStr}`);
 	}
 


### PR DESCRIPTION
# PR details

## What changes did you make? (Give an overview)

Retrieve, Deploy and Copy to BU command are now available in the Command Palette (alt + ctrl + p) and run on the active tab file.

![image](https://github.com/Accenture/sfmc-devtools-vscode/assets/66126240/da6e32bc-f212-4aec-95d9-aa29c979a14a)


Closes #163 #62 
