### PR TITLE
mcdev commands available on editor context 

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,18 +76,21 @@
                "group": "devtools"
             }
          ],
-         "commandPalette": [
+         "editor/context": [
             {
+               "when": "sfmc-devtools-vscode.isDevToolsProject && resourcePath =~ /retrieve/",
                "command": "sfmc-devtools-vscext.devtoolsCMRetrieve",
-               "when": "false"
+               "group": "devtools"
             },
             {
+               "when": "sfmc-devtools-vscode.isDevToolsProject && (resourcePath =~ /deploy/ || (resourcePath =~ /retrieve/ && (resourceExtname == '.json' || resourceExtname == '.html' || resourceExtname == '.sql' || resourceExtname == '.ssjs' || resourceLangId == 'markdown' || resourceLangId == 'AMPscript' || resourceLangId == 'ampscript' || resourceDirname =~ /asset\\\\[a-zA-Z]*/)))",
                "command": "sfmc-devtools-vscext.devtoolsCMDeploy",
-               "when": "false"
+               "group": "devtools"
             },
             {
+               "when": "sfmc-devtools-vscode.isDevToolsProject && resourcePath =~ /retrieve/ && resourceFilename != 'retrieve' && resourceFilename != 'deploy'",
                "command": "sfmc-devtools-vscext.devtoolsCMCopyToBU",
-               "when": "false"
+               "group": "devtools"
             }
          ],
          "editor/title/context": [
@@ -105,6 +108,20 @@
                "when": "sfmc-devtools-vscode.isDevToolsProject && resourcePath =~ /retrieve/ && resourceFilename != 'retrieve' && resourceFilename != 'deploy'",
                "command": "sfmc-devtools-vscext.devtoolsCMCopyToBU",
                "group": "devtools"
+            }
+         ],
+         "commandPalette": [
+            {
+               "command": "sfmc-devtools-vscext.devtoolsCMRetrieve",
+               "when": "false"
+            },
+            {
+               "command": "sfmc-devtools-vscext.devtoolsCMDeploy",
+               "when": "false"
+            },
+            {
+               "command": "sfmc-devtools-vscext.devtoolsCMCopyToBU",
+               "when": "false"
             }
          ]
       },


### PR DESCRIPTION
# PR details

## What changes did you make? (Give an overview)

The Retrieve, Deploy and Copy to BU commands are now also available when the user righ clicks on the file content in the menu that shows up. 

![image](https://github.com/Accenture/sfmc-devtools-vscode/assets/66126240/466871bd-51f3-4c0f-9802-d4016b299816)


Closes #112 
