### PR TITLE
removed logic of requesting user to select metadatatype for retrieve …

### DIFF
--- a/src/devtools/commands/DevToolsAdminCommands.ts
+++ b/src/devtools/commands/DevToolsAdminCommands.ts
@@ -59,11 +59,7 @@ class DevToolsAdminCommands extends DevToolsCommands {
 			}
 			log("debug", `Init payload: ${JSON.stringify(initArgs)}`);
 
-			const commandConfigured: string | undefined = await this.configureCommandWithParameters(
-				config,
-				initArgs,
-				[]
-			);
+			const commandConfigured: string | undefined = await this.configureCommandWithParameters(config, initArgs);
 			// Checks if the command is still missing so required parameter
 			if (this.hasPlaceholders(commandConfigured)) {
 				log("debug", `Required Parameters missing from Init command: ${commandConfigured}`);
@@ -89,11 +85,7 @@ class DevToolsAdminCommands extends DevToolsCommands {
 		try {
 			log("info", `Running DevTools Admin Command: Explain Types...`);
 			if ("command" in config && config.command) {
-				const commandConfigured: string | undefined = await this.configureCommandWithParameters(
-					config,
-					args,
-					[]
-				);
+				const commandConfigured: string | undefined = await this.configureCommandWithParameters(config, args);
 				log("debug", `Explain types final command: ${commandConfigured}`);
 				const commandResult: string | number = await this.executeCommand(
 					commandConfigured,

--- a/src/devtools/commands/DevToolsCommands.ts
+++ b/src/devtools/commands/DevToolsCommands.ts
@@ -44,8 +44,7 @@ abstract class DevToolsCommands {
 
 	async configureCommandWithParameters(
 		config: DevToolsCommandSetting,
-		args: { [key: string]: string | string[] | boolean },
-		mdTypes: SupportedMetadataTypes[]
+		args: { [key: string]: string | string[] | boolean }
 	): Promise<string> {
 		log("debug", `ConfigureCommandWithParameters: ${JSON.stringify(config)}`);
 		let { command } = config;
@@ -54,14 +53,6 @@ abstract class DevToolsCommands {
 			for (const param of config.requiredParams) {
 				if (param in args && args[param]) {
 					command = command.replace(`{{${param}}}`, args[param] as string);
-				} else {
-					// Requests user
-					if (param.toLowerCase() === "mdtypes" && mdTypes.length) {
-						const userSelecteMDTypes: string | undefined = await this.handleMetadataTypeRequest(mdTypes);
-						if (userSelecteMDTypes) {
-							command = command.replace(`{{${param}}}`, `"${userSelecteMDTypes}"`);
-						}
-					}
 				}
 			}
 		}
@@ -76,26 +67,6 @@ abstract class DevToolsCommands {
 			});
 		}
 		return command;
-	}
-
-	async handleMetadataTypeRequest(mdTypes: SupportedMetadataTypes[]): Promise<string | undefined> {
-		const mdTypeInputOptions: InputOptionsSettings[] = mdTypes.map((mdType: SupportedMetadataTypes) => ({
-			id: mdType.apiName,
-			label: mdType.name,
-			detail: ""
-		}));
-		const userResponse: InputOptionsSettings | InputOptionsSettings[] | undefined =
-			await editorInput.handleQuickPickSelection(
-				mdTypeInputOptions,
-				"Please select one or multiple metadata types...",
-				true
-			);
-		if (userResponse && Array.isArray(userResponse)) {
-			const mdTypes: string = `${userResponse.map((response: InputOptionsSettings) => response.id)}`;
-			log("debug", `User selected metadata types: "${mdTypes}"`);
-			return mdTypes;
-		}
-		return;
 	}
 
 	hasPlaceholders(command: string): boolean {

--- a/src/devtools/commands/DevToolsStandardCommands.ts
+++ b/src/devtools/commands/DevToolsStandardCommands.ts
@@ -70,15 +70,8 @@ class DevToolsStandardCommands extends DevToolsCommands {
 	) {
 		log("info", `Running DevTools Standard Command: Retrieve...`);
 		if ("command" in config && config.command) {
-			// Gets that metadata types that are supported for retrieve
-			const supportedMdTypes: SupportedMetadataTypes[] = this.getSupportedMetadataTypeByAction("retrieve");
-
 			// Configures the command to replace all the parameters with the values
-			const commandConfigured: string | undefined = await this.configureCommandWithParameters(
-				config,
-				args,
-				supportedMdTypes
-			);
+			const commandConfigured: string | undefined = await this.configureCommandWithParameters(config, args);
 
 			// Checks if the command is still missing so required parameter
 			if (this.hasPlaceholders(commandConfigured)) {
@@ -89,6 +82,7 @@ class DevToolsStandardCommands extends DevToolsCommands {
 
 			log("debug", `Retrieve Command configured: ${commandConfigured}`);
 			loadingNotification();
+
 			const commandResult: string | number = await this.executeCommand(commandConfigured, path, true);
 			if (typeof commandResult === "number") {
 				handleCommandResult({ success: commandResult === 0, cancelled: false });
@@ -106,15 +100,8 @@ class DevToolsStandardCommands extends DevToolsCommands {
 	) {
 		log("info", `Running DevTools Standard Command: Deploy...`);
 		if ("command" in config && config.command) {
-			// Gets that metadata types that are supported for deploy
-			const supportedMdTypes: SupportedMetadataTypes[] = this.getSupportedMetadataTypeByAction("deploy");
-
 			// Configures the command to replace all the parameters with the values
-			const commandConfigured: string | undefined = await this.configureCommandWithParameters(
-				config,
-				args,
-				supportedMdTypes
-			);
+			const commandConfigured: string | undefined = await this.configureCommandWithParameters(config, args);
 
 			// Checks if the command is still missing so required parameter
 			if (this.hasPlaceholders(commandConfigured)) {
@@ -125,6 +112,7 @@ class DevToolsStandardCommands extends DevToolsCommands {
 
 			log("debug", `Deploy Command configured: ${commandConfigured}`);
 			loadingNotification();
+
 			const commandResult: string | number = await this.executeCommand(commandConfigured, path, true);
 			if (typeof commandResult === "number") {
 				handleCommandResult({ success: commandResult === 0, cancelled: false });

--- a/src/devtools/commands/commands.config.json
+++ b/src/devtools/commands/commands.config.json
@@ -41,8 +41,8 @@
                 "id":"retrieve", 
                 "title": "Retrieve", 
                 "command": "mcdev retrieve {{bu}} {{mdtypes}} {{key}} --skipInteraction", 
-                "requiredParams": ["bu", "mdtypes"],
-                "optionalParams": ["key"],
+                "requiredParams": ["bu"],
+                "optionalParams": ["key", "mdtypes"],
                 "description": "Retrieves metadata of a business unit.", 
                 "isAvailable": true
             },
@@ -50,8 +50,8 @@
                 "id":"deploy", 
                 "title": "Deploy", 
                 "command": "mcdev deploy {{bu}} {{mdtypes}} {{key}} {{fromRetrieve}} --skipInteraction", 
-                "requiredParams": ["bu", "mdtypes"],
-                "optionalParams": ["key", "fromRetrieve"],
+                "requiredParams": ["bu"],
+                "optionalParams": ["key", "mdtypes", "fromRetrieve"],
                 "description": "Deploys local metadata to a business unit.", 
                 "isAvailable": true
             },


### PR DESCRIPTION
# PR details

## What changes did you make? (Give an overview)

Removed logic that asks user to select which metadata type they wish to retrieve or deploy. With this PR user will now download all the metadata types when retrieving from retrieve/cred/bu folder. 

- closes #193 
