### PR TITLE
Bug/196 copy to bu fails when trying to copy from the credential and business unit folder

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
                "group": "devtools"
             },
             {
-               "when": "sfmc-devtools-vscode.isDevToolsProject && resourcePath =~ /retrieve/ && resourceFilename != 'retrieve' && resourceFilename != 'deploy'",
+               "when": "sfmc-devtools-vscode.isDevToolsProject && resourcePath =~ /retrieve/ && resourceFilename != 'retrieve' && resourceFilename != 'deploy' && resourcePath =~ /retrieve\\\\.*\\\\.*/",
                "command": "sfmc-devtools-vscext.devtoolsCMCopyToBU",
                "group": "devtools"
             }
@@ -119,7 +119,7 @@
                "group": "devtools"
             },
             {
-               "when": "sfmc-devtools-vscode.isDevToolsProject && resourcePath =~ /retrieve/ && resourceFilename != 'retrieve' && resourceFilename != 'deploy'",
+               "when": "sfmc-devtools-vscode.isDevToolsProject && resourcePath =~ /retrieve/ && resourceFilename != 'retrieve' && resourceFilename != 'deploy' && resourcePath =~ /retrieve\\\\.*\\\\.*/",
                "command": "sfmc-devtools-vscext.devtoolsCMCopyToBU",
                "group": "devtools"
             }

--- a/src/devtools/commands/DevToolsCommands.ts
+++ b/src/devtools/commands/DevToolsCommands.ts
@@ -3,7 +3,6 @@ import * as commandsConfig from "./commands.config.json";
 import DevToolsCommandSetting from "../../shared/interfaces/devToolsCommandSetting";
 import DevToolsCommandRunner from "../../shared/interfaces/devToolsCommandRunner";
 import SupportedMetadataTypes from "../../shared/interfaces/supportedMetadataTypes";
-import InputOptionsSettings from "../../shared/interfaces/inputOptionsSettings";
 import { editorInput } from "../../editor/input";
 import { log } from "../../editor/output";
 import { lib } from "../../shared/utils/lib";
@@ -13,10 +12,9 @@ import { metadatatypes } from "../../config/metadatatypes.config";
 abstract class DevToolsCommands {
 	static readonly commandPrefix: string = "mcdev";
 	static commandMap: { [key: string]: DevToolsCommands };
+	static metadataTypes: SupportedMetadataTypes[];
 
 	abstract run(commandRunner: DevToolsCommandRunner): void;
-	abstract setMetadataTypes(mdTypes: SupportedMetadataTypes[]): void;
-	abstract getMetadataTypes(): SupportedMetadataTypes[] | void;
 	abstract isSupportedMetadataType(action: string, metadataType: string): boolean | void;
 
 	executeCommand(command: string, path: string, showOnTerminal: boolean): Promise<string | number> {
@@ -101,14 +99,11 @@ abstract class DevToolsCommands {
 			}, {});
 		}
 
-		// Sends the supported mtdata types to each DevTools Command
-		Object.keys(this.commandMap).forEach((key: string) => {
-			const devToolCommand: DevToolsCommands = this.commandMap[key];
-			const sortedSuppMdtByName: SupportedMetadataTypes[] = metadatatypes.sort((a, b) =>
-				a.name.localeCompare(b.name)
-			);
-			devToolCommand.setMetadataTypes(sortedSuppMdtByName);
-		});
+		// Sets the metadata types sorted by name
+		const sortedSuppMdtByName: SupportedMetadataTypes[] = metadatatypes.sort((a, b) =>
+			a.name.localeCompare(b.name)
+		);
+		this.setMetadataTypes(sortedSuppMdtByName);
 	}
 
 	static async runCommand(
@@ -188,6 +183,14 @@ abstract class DevToolsCommands {
 		}
 		log("error", `[DevToolsCommands_runCommand] Error: Failed to retrieve ${id} from commands configuration.`);
 		return false;
+	}
+
+	static setMetadataTypes(mdTypes: SupportedMetadataTypes[]): void {
+		this.metadataTypes = mdTypes;
+	}
+
+	static getMetadataTypes(): SupportedMetadataTypes[] {
+		return this.metadataTypes;
 	}
 
 	static isSupportedMetadataType(action: string, metadataType: string) {

--- a/src/devtools/commands/DevToolsStandardCommands.ts
+++ b/src/devtools/commands/DevToolsStandardCommands.ts
@@ -13,7 +13,6 @@ class DevToolsStandardCommands extends DevToolsCommands {
 			commandHandlers: { [key: string]: (args?: any) => void }
 		) => void;
 	} = {};
-	private metadataTypes: SupportedMetadataTypes[] = [];
 	constructor() {
 		super();
 		log("debug", "DevToolsStandardCommands Class created");
@@ -35,20 +34,14 @@ class DevToolsStandardCommands extends DevToolsCommands {
 		}
 	}
 
-	setMetadataTypes(mdTypes: SupportedMetadataTypes[]): void {
-		this.metadataTypes = mdTypes;
-	}
-
-	getMetadataTypes(): SupportedMetadataTypes[] {
-		return this.metadataTypes;
-	}
-
 	getSupportedMetadataTypeByAction(action: string) {
 		const supportedActions: { [key: string]: () => SupportedMetadataTypes[] } = {
 			retrieve: () =>
-				this.getMetadataTypes().filter((mdType: SupportedMetadataTypes) => mdType.supports.retrieve),
+				DevToolsCommands.getMetadataTypes().filter(
+					(mdType: SupportedMetadataTypes) => mdType.supports.retrieve
+				),
 			deploy: () =>
-				this.getMetadataTypes().filter(
+				DevToolsCommands.getMetadataTypes().filter(
 					(mdType: SupportedMetadataTypes) => mdType.supports.create || mdType.supports.update
 				)
 		};

--- a/src/devtools/main.ts
+++ b/src/devtools/main.ts
@@ -734,7 +734,6 @@ async function handleCopyToBuCMCommand(selectedPaths: string[]) {
 									}
 
 									return buSelected
-										.filter((buSelected: string) => buSelected !== businessUnit)
 										.map((buSelected: string) =>
 											paths.map((keyFilePath: string) => ({
 												sourceFilePath: keyFilePath,

--- a/src/devtools/main.ts
+++ b/src/devtools/main.ts
@@ -15,6 +15,7 @@ import DevToolsPathComponents from "../shared/interfaces/devToolsPathComponents"
 import { lib } from "../shared/utils/lib";
 import { file } from "../shared/utils/file";
 import { editorCommands } from "../editor/commands";
+import SupportedMetadataTypes from "../shared/interfaces/supportedMetadataTypes";
 
 async function initDevToolsExtension(): Promise<void> {
 	try {
@@ -622,7 +623,23 @@ async function handleCopyToBuCMCommand(selectedPaths: string[]) {
 		const { supportedMetadataTypes, unsupportedMetadataTypes }: SupportedMetadataTypeConfiguration =
 			configuredSelectedPaths.reduce(
 				(accObj: SupportedMetadataTypeConfiguration, configPath: DevToolsPathConfiguration) => {
-					if (DevToolsCommands.isSupportedMetadataType("deploy", configPath.metadataType)) {
+					if (!configPath.metadataType) {
+						// Gets all the metadata types that are supported for deployment
+						const allDeployMetadataTypes: SupportedMetadataTypes[] =
+							DevToolsCommands.getMetadataTypes().filter((mdType: SupportedMetadataTypes) =>
+								DevToolsCommands.isSupportedMetadataType("deploy", mdType.apiName)
+							);
+						// Configures and adds all the metadata types that exist in the BU folder
+						accObj.supportedMetadataTypes = allDeployMetadataTypes
+							.map((mdType: SupportedMetadataTypes) => ({
+								...configPath,
+								absolutePath: `${configPath.absolutePath}/${mdType.apiName}`,
+								metadataType: mdType.apiName
+							}))
+							.filter((pathConfig: DevToolsPathConfiguration) =>
+								file.isPathADirectory(pathConfig.absolutePath)
+							);
+					} else if (DevToolsCommands.isSupportedMetadataType("deploy", configPath.metadataType)) {
 						accObj.supportedMetadataTypes.push(configPath);
 					} else {
 						accObj.unsupportedMetadataTypes = lib.removeDuplicates([

--- a/src/shared/utils/file.ts
+++ b/src/shared/utils/file.ts
@@ -18,11 +18,7 @@ function fileExists(path: string | string[]): string[] {
 }
 
 function isPathADirectory(path: string): boolean {
-	try {
-		return fs.lstatSync(path.replace(/^\/[a-zA-Z]:/g, "")).isDirectory();
-	} catch (error) {
-		throw error;
-	}
+	return fileExists(path).length > 0 && fs.lstatSync(path.replace(/^\/[a-zA-Z]:/g, "")).isDirectory();
 }
 
 function createFilePath(pathArray: string[]): string {


### PR DESCRIPTION
# PR details

## What changes did you make? (Give an overview)

- Updated package.json to make the menu option "mcdev: Copy .." unavailable when the user clicks on the credential folder.
- Added logic to copy all the valid for deploy metadata types when a user clicks on "mcdev: Copy..." on the business unit folder level.
- Copy to same Business Unit is now allowed in "mcdev: Copy ...".

closes #196  
