### PR TITLE
Feature/202 update default metadata types file by running mcdev explaintypes in background

### DIFF
--- a/src/config/metadatatypes.config.ts
+++ b/src/config/metadatatypes.config.ts
@@ -1,4 +1,6 @@
-export const metadatatypes = [
+import SupportedMetadataTypes from "../shared/interfaces/supportedMetadataTypes";
+
+export const metadatatypes: SupportedMetadataTypes[] = [
 	{
 		name: "Asset-[Subtype]",
 		apiName: "asset",

--- a/src/devtools/commands/DevToolsAdminCommands.ts
+++ b/src/devtools/commands/DevToolsAdminCommands.ts
@@ -34,8 +34,6 @@ class DevToolsAdminCommands extends DevToolsCommands {
 		}
 	}
 
-	getMetadataTypes(): SupportedMetadataTypes[] | void {}
-	setMetadataTypes(_: SupportedMetadataTypes[]): void {}
 	isSupportedMetadataType(_action: string, _metadataType: string): boolean | void {}
 
 	async init(

--- a/src/devtools/commands/DevToolsAdminCommands.ts
+++ b/src/devtools/commands/DevToolsAdminCommands.ts
@@ -1,7 +1,6 @@
 import DevToolsCommands from "./DevToolsCommands";
 import DevToolsCommandSetting from "../../shared/interfaces/devToolsCommandSetting";
 import DevToolsCommandRunner from "../../shared/interfaces/devToolsCommandRunner";
-import SupportedMetadataTypes from "../../shared/interfaces/supportedMetadataTypes";
 import { log } from "../../editor/output";
 
 class DevToolsAdminCommands extends DevToolsCommands {

--- a/src/devtools/commands/DevToolsCommands.ts
+++ b/src/devtools/commands/DevToolsCommands.ts
@@ -99,11 +99,23 @@ abstract class DevToolsCommands {
 			}, {});
 		}
 
-		// Sets the metadata types sorted by name
-		const sortedSuppMdtByName: SupportedMetadataTypes[] = metadatatypes.sort((a, b) =>
-			a.name.localeCompare(b.name)
+		// sets default metadata type file
+		this.setMetadataTypes(metadatatypes);
+
+		// Updates metadatypes with the result from explainTypes command, not blocking code execution
+		this.runCommand(
+			"admin",
+			"etypes",
+			"",
+			{ json: true },
+			{
+				handleCommandResult: ({ success, data }: { success: boolean; data: string }) => {
+					if (success) {
+						this.setMetadataTypes(JSON.parse(data) as SupportedMetadataTypes[]);
+					}
+				}
+			}
 		);
-		this.setMetadataTypes(sortedSuppMdtByName);
 	}
 
 	static async runCommand(


### PR DESCRIPTION
# PR details

## What changes did you make? (Give an overview)

- Updated init method in order to call the mcdev explainType to update the metadatypes variable with the latest metadata permissions. This command call is not blocking the code execution.

closes #202 
