### PR TITLE
Feature/116 implement delete from server

### DIFF
--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
             },
             {
                "command": "sfmc-devtools-vscode.delete",
-               "when": "sfmc-devtools-vscode.config.isproject && resourcePath =~ /\\\\retrieve\\\\/ && resourceExtname =~ /.(json|html|sql|ssjs|md|amp|txt)/",
+               "when": "sfmc-devtools-vscode.config.isproject && resourcePath =~ /\\\\retrieve\\\\/ && (resourceExtname =~ /.(json|html|sql|ssjs|md|amp|txt)/ || resourceDirname =~ /asset\\\\[a-zA-Z]*/)",
                "group": "devtools"
             }
          ],
@@ -121,7 +121,7 @@
             },
             {
                "command": "sfmc-devtools-vscode.delete",
-               "when": "sfmc-devtools-vscode.config.isproject && resourcePath =~ /\\\\retrieve\\\\/ && resourceExtname =~ /.(json|html|sql|ssjs|md|amp|txt)/",
+               "when": "sfmc-devtools-vscode.config.isproject && resourcePath =~ /\\\\retrieve\\\\/ && (resourceExtname =~ /.(json|html|sql|ssjs|md|amp|txt)/ || resourceDirname =~ /asset\\\\[a-zA-Z]*/)",
                "group": "devtools"
             }
          ],

--- a/package.json
+++ b/package.json
@@ -56,6 +56,10 @@
          {
             "command": "sfmc-devtools-vscode.copytobu",
             "title": "mcdev: Copy to Business Unit..."
+         },
+         {
+            "command": "sfmc-devtools-vscode.delete",
+            "title": "mcdev: Delete From Server"
          }
       ],
       "menus": {
@@ -71,6 +75,10 @@
             {
                "command": "sfmc-devtools-vscode.copytobu",
                "when": "sfmc-devtools-vscode.config.isproject && editorIsOpen && resourcePath =~ /\\\\retrieve\\\\.*\\\\.*/"
+            },
+            {
+               "command": "sfmc-devtools-vscode.delete",
+               "when": "sfmc-devtools-vscode.config.isproject && editorIsOpen && resourcePath =~ /\\\\retrieve\\\\/ && resourceExtname =~ /.(json|html|sql|ssjs|md|amp|txt)/"
             }
          ],
          "editor/context": [
@@ -87,6 +95,11 @@
             {
                "command": "sfmc-devtools-vscode.copytobu",
                "when": "sfmc-devtools-vscode.config.isproject && resourcePath =~ /\\\\retrieve\\\\.*\\\\.*/",
+               "group": "devtools"
+            },
+            {
+               "command": "sfmc-devtools-vscode.delete",
+               "when": "sfmc-devtools-vscode.config.isproject && resourcePath =~ /\\\\retrieve\\\\/ && resourceExtname =~ /.(json|html|sql|ssjs|md|amp|txt)/",
                "group": "devtools"
             }
          ],
@@ -105,6 +118,11 @@
                "command": "sfmc-devtools-vscode.copytobu",
                "when": "sfmc-devtools-vscode.config.isproject && resourcePath =~ /\\\\retrieve\\\\.*\\\\.*/",
                "group": "devtools"
+            },
+            {
+               "command": "sfmc-devtools-vscode.delete",
+               "when": "sfmc-devtools-vscode.config.isproject && resourcePath =~ /\\\\retrieve\\\\/ && resourceExtname =~ /.(json|html|sql|ssjs|md|amp|txt)/",
+               "group": "devtools"
             }
          ],
          "editor/title/context": [
@@ -121,6 +139,11 @@
             {
                "command": "sfmc-devtools-vscode.copytobu",
                "when": "sfmc-devtools-vscode.config.isproject && resourcePath =~ /\\\\retrieve\\\\.*\\\\.*/",
+               "group": "devtools"
+            },
+            {
+               "command": "sfmc-devtools-vscode.delete",
+               "when": "sfmc-devtools-vscode.config.isproject && resourcePath =~ /\\\\retrieve\\\\/ && resourceExtname =~ /.(json|html|sql|ssjs|md|amp|txt)/",
                "group": "devtools"
             }
          ]

--- a/src/config/devtools.ts
+++ b/src/config/devtools.ts
@@ -1,7 +1,7 @@
 const extensionName = "sfmc-devtools-vscode";
 const requiredFiles = [".mcdevrc.json", ".mcdev-auth.json"];
 const recommendedExtensions = ["IBM.output-colorizer"];
-const menuCommands = ["retrieve", "deploy", "copytobu"];
+const menuCommands = ["retrieve", "deploy", "copytobu", "delete"];
 const delayTimeUpdateStatusBar = 10000; // 10 seconds
 
 export { extensionName, requiredFiles, recommendedExtensions, menuCommands, delayTimeUpdateStatusBar };

--- a/src/devtools/commands/standard.ts
+++ b/src/devtools/commands/standard.ts
@@ -110,6 +110,12 @@ class StandardCommands extends Commands {
 		return { alias: deployAlias, config: deployConfig };
 	}
 
+	/**
+	 * Standard Command 'delete' execution
+	 *
+	 * @param {TDevTools.ICommandParameters[]} parameters - command parameters
+	 * @returns {TDevTools.ICommandConfig} command configuration
+	 */
 	delete(parameters: TDevTools.ICommandParameters[]): TDevTools.ICommandConfig {
 		console.log("== StandardCommands: Delete ==");
 		// command alias

--- a/src/devtools/commands/standard.ts
+++ b/src/devtools/commands/standard.ts
@@ -8,7 +8,8 @@ import { TDevTools } from "@types";
  */
 enum StandardCommandsAlias {
 	retrieve = "r",
-	deploy = "d"
+	deploy = "d",
+	delete = "del"
 }
 
 /**
@@ -48,6 +49,9 @@ class StandardCommands extends Commands {
 				break;
 			case "deploy":
 				config = this.deploy(parameters);
+				break;
+			case "delete":
+				config = this.delete(parameters);
 				break;
 		}
 		return config;
@@ -104,6 +108,17 @@ class StandardCommands extends Commands {
 		const deployConfig = parameters.map(parameter => [this.configureParameters(parameter), parameter.projectPath]);
 
 		return { alias: deployAlias, config: deployConfig };
+	}
+
+	delete(parameters: TDevTools.ICommandParameters[]): TDevTools.ICommandConfig {
+		console.log("== StandardCommands: Delete ==");
+		// command alias
+		const deleteAlias = StandardCommandsAlias.delete;
+
+		// command parameters configuration
+		const deleteConfig = parameters.map(parameter => [this.configureParameters(parameter), parameter.projectPath]);
+
+		return { alias: deleteAlias, config: deleteConfig };
 	}
 }
 

--- a/src/devtools/index.ts
+++ b/src/devtools/index.ts
@@ -3,7 +3,7 @@ import { ConfigDevTools } from "@config";
 import { MessagesDevTools, MessagesEditor } from "@messages";
 import { EnumsExtension } from "@enums";
 import { TEditor, TUtils } from "@types";
-import { File, Lib } from "utils";
+import { Lib } from "utils";
 
 /**
  * DevTools Extension class
@@ -417,7 +417,14 @@ class DevToolsExtension {
 		);
 	}
 
-	executeMenuCommand(command: string, files: string[]) {
+	/**
+	 * Executes the Menu Command by command name
+	 *
+	 * @param {string} command - command name
+	 * @param {string[]} files - selected files paths
+	 * @returns {void}
+	 */
+	executeMenuCommand(command: string, files: string[]): void {
 		const menuCommandsHandlers: { [key: string]: () => void } = {
 			retrieve: () => this.handleRetrieveCommand(files),
 			deploy: () => this.handleDeployCommand(files),
@@ -434,18 +441,40 @@ class DevToolsExtension {
 			);
 	}
 
-	handleRetrieveCommand(files: string[]) {
+	/**
+	 * Handles the Menu Command 'retrieve'
+	 *
+	 * @param {string[]} files - selected files paths
+	 * @returns {void}
+	 */
+	handleRetrieveCommand(files: string[]): void {
 		this.executeCommand("retrieve", files);
 	}
 
-	handleDeployCommand(files: string[]) {
+	/**
+	 * Handles the Menu Command 'deploy'
+	 *
+	 * @param {string[]} files - selected files paths
+	 * @returns {void}
+	 */
+	handleDeployCommand(files: string[]): void {
 		this.executeCommand("deploy", files);
 	}
 
-	async handleDeleteCommand(files: string[]) {
+	/**
+	 * Handles the Menu Command 'delete'
+	 *
+	 * @async
+	 * @param {string[]} files - selected files paths
+	 * @returns {Promise<void>}
+	 */
+	async handleDeleteCommand(files: string[]): Promise<void> {
+		const fileNamesList = this.mcdev
+			.convertPathsToFiles(files)
+			.map(file => `${file.filename} (${file.metadataType})`);
 		const confirmationAnswer = await this.showInformationMessage(
 			"info",
-			MessagesEditor.deleteConfirmation(File.extractFileName(files)),
+			MessagesEditor.deleteConfirmation(fileNamesList),
 			Object.keys(EnumsExtension.Confirmation),
 			true
 		);

--- a/src/devtools/mcdev.ts
+++ b/src/devtools/mcdev.ts
@@ -100,11 +100,11 @@ class Mcdev {
 	/**
 	 * Convert files paths to DevTools File Format
 	 *
-	 * @private
+	 * @public
 	 * @param {string[]} paths - file paths
 	 * @returns {TDevTools.IFileFormat[]} files formatted in DevTool File Format
 	 */
-	private convertPathsToFiles(paths: string[]): TDevTools.IFileFormat[] {
+	public convertPathsToFiles(paths: string[]): TDevTools.IFileFormat[] {
 		console.log("== Mcdev: Convert File Paths ==");
 
 		const convertToFileFormat = (path: string): TDevTools.IFileFormat => {
@@ -319,6 +319,7 @@ class Mcdev {
 				commandHandler({
 					info: `${MessagesDevTools.mcdevRunningCommand} ${this.getPackageName()} ${commandConfig.alias} ${parameters}\n`
 				});
+
 				const { success }: TUtils.ITerminalCommandResult = await Terminal.executeTerminalCommand(
 					terminalConfig,
 					false

--- a/src/devtools/metadatatypes.ts
+++ b/src/devtools/metadatatypes.ts
@@ -100,12 +100,12 @@ class MetadataTypes {
 			// configuration for asset mdtype
 			if (files.length === 1) return { metadataTypeName: `asset-${assetName}` };
 			else if (files.length > 1)
-				return { metadataTypeName: `asset-${assetName}`, filename: File.extractFileName(filename)[0] };
+				return { metadataTypeName: `asset-${assetName}`, filename: File.extractNameFromPath(filename)[0] };
 		}
 
 		if (files.length === 1 || mdt === "folder") {
 			// configuration for other mdtypes
-			const filenames = File.extractFileName(files);
+			const filenames = File.extractNameFromPath(files);
 			if (filenames.length) return { filename: filenames[0] };
 		}
 		return { filename: "" };

--- a/src/devtools/metadatatypes.ts
+++ b/src/devtools/metadatatypes.ts
@@ -9,7 +9,8 @@ import { File } from "utils";
  */
 const MetadataTypesSupportedActions: { [action: string]: TDevTools.MetadataTypesActions[] } = {
 	retrieve: ["retrieve"],
-	deploy: ["create", "update"]
+	deploy: ["create", "update"],
+	delete: ["delete"]
 };
 
 /**

--- a/src/editor/window.ts
+++ b/src/editor/window.ts
@@ -46,8 +46,12 @@ class VSCodeWindow {
 	 * @param {string[]} actions - modal action options
 	 * @returns {Promise<string | undefined>} option selected by user or undefined if no selection
 	 */
-	async showInformationMessageWithOptions(message: string, actions: string[]): Promise<string | undefined> {
-		const response = await this.window.showInformationMessage(message, ...actions);
+	async showInformationMessageWithOptions(
+		message: string,
+		actions: string[],
+		modal: boolean
+	): Promise<string | undefined> {
+		const response = await this.window.showInformationMessage(message, { modal }, ...actions);
 		return response;
 	}
 

--- a/src/enums/extension.ts
+++ b/src/enums/extension.ts
@@ -30,7 +30,8 @@ enum StatusBarIcon {
 	deploy = "cloud-upload",
 	error = "warning",
 	copytobu = "file-symlink-directory",
-	info = "extensions-info-message"
+	info = "extensions-info-message",
+	delete = "trash"
 }
 
 /**

--- a/src/messages/editor.ts
+++ b/src/messages/editor.ts
@@ -3,5 +3,12 @@ const recommendedExtensions =
 const runningCommand = "Running DevTools command...";
 const runningCommandSuccess = "DevTools command has run successfully!";
 const runningCommandFailure = "Oh no. Something went wrong while running DevTools Command...";
+const deleteConfirmation = (items: string[]) =>
+	`Are you sure you want to delete the selected item${items.length > 1 ? "s" : ""} from the server?\n\n${items
+		.slice(0, 3)
+		.map(item => `Delete: ${item}`)
+		.join(
+			"\n"
+		)}${items.length > 3 ? `\n...and ${items.length - 3} more item${items.length - 3 > 1 ? "s" : ""}.` : ""}`;
 
-export { recommendedExtensions, runningCommand, runningCommandSuccess, runningCommandFailure };
+export { recommendedExtensions, runningCommand, runningCommandSuccess, runningCommandFailure, deleteConfirmation };

--- a/src/utils/file.ts
+++ b/src/utils/file.ts
@@ -22,9 +22,11 @@ function fileExists(path: string | string[]): string[] {
  */
 function extractFileName(files: string | string[]): string[] {
 	return [files].flat().map(file => {
-		const endOfFileNameIndex = file.lastIndexOf(".", file.lastIndexOf(".") - 1);
-		if (endOfFileNameIndex < 0) return file;
-		return file.substring(0, endOfFileNameIndex);
+		const fileName = file.split(/[\/]/).pop() || file;
+		const lastDotIndex = fileName.lastIndexOf(".");
+		const secondLastDotIndex = fileName.lastIndexOf(".", fileName.lastIndexOf(".") - 1);
+		if (secondLastDotIndex < 0) return file.substring(0, lastDotIndex);
+		return fileName.substring(0, secondLastDotIndex);
 	});
 }
 

--- a/src/utils/file.ts
+++ b/src/utils/file.ts
@@ -20,9 +20,15 @@ function fileExists(path: string | string[]): string[] {
  * @param {(string | string[])} files - file paths
  * @returns {string[]} list of extracted file names
  */
-function extractFileName(files: string | string[]): string[] {
+function extractNameFromPath(files: string | string[]): string[] {
 	return [files].flat().map(file => {
+		// splits path
 		const fileName = file.split(/[\/]/).pop() || file;
+
+		// returns folder name
+		if (!fileName.includes(".")) return fileName;
+
+		// if it's a file in format filename.asset-asset-meta.ext
 		const lastDotIndex = fileName.lastIndexOf(".");
 		const secondLastDotIndex = fileName.lastIndexOf(".", fileName.lastIndexOf(".") - 1);
 		if (secondLastDotIndex < 0) return file.substring(0, lastDotIndex);
@@ -30,4 +36,4 @@ function extractFileName(files: string | string[]): string[] {
 	});
 }
 
-export { fileExists, extractFileName };
+export { fileExists, extractNameFromPath };


### PR DESCRIPTION
# PR details

## What changes did you make? (Give an overview)

- Implemented mcdev delete command into the extension. This command will only be executed for files or folders inside the asset-subtype. 
- Confirmation of deletion message is shown before running the command.
- Code checks if delete action is valid for a certain metadata type. If not it shows an error message in the Output channel.

![image](https://github.com/user-attachments/assets/b8a3eea6-111e-40b9-9aa3-8e125b935bc8)
![image](https://github.com/user-attachments/assets/da35e794-11af-4a91-8bef-ba02522fcd4d)


